### PR TITLE
Fixes for Python 3 compatibility

### DIFF
--- a/char_rnn_model.py
+++ b/char_rnn_model.py
@@ -216,7 +216,7 @@ class CharRNN(object):
     state = session.run(self.zero_state)
     self.reset_loss_monitor.run()
     start_time = time.time()
-    for step in range(epoch_size / divide_by_n):
+    for step in range(epoch_size // divide_by_n):
       # Generate the batch and use [:-1] as inputs and [1:] as targets.
       data = batch_generator.next()
       inputs = np.array(data[:-1]).transpose()

--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ import sys
 
 import numpy as np
 from char_rnn_model import *
+from six import iteritems
 
 
 def main():
@@ -364,7 +365,7 @@ def load_vocab(vocab_file, encoding):
         vocab_index_dict = json.load(f)
     index_vocab_dict = {}
     vocab_size = 0
-    for char, index in vocab_index_dict.iteritems():
+    for char, index in iteritems(vocab_index_dict):
         index_vocab_dict[index] = char
         vocab_size += 1
     return vocab_index_dict, index_vocab_dict, vocab_size


### PR DESCRIPTION
* Use six.iteritems to ensure lazy iteration on both Python 2 and Python 3
* Use integer division when dividing epoch_size by n_save